### PR TITLE
Fixed issue with default executable launching

### DIFF
--- a/pkg/client/open.go
+++ b/pkg/client/open.go
@@ -37,6 +37,7 @@ func (c *Client) Open(path string, output string) error {
 		}
 
 		file.Exec = exec
+		file.Addons = &[]executable.Addon{}
 	} else {
 		loaded, err := c.load(path)
 		if err != nil {

--- a/pkg/cmd/cli/command/open.go
+++ b/pkg/cmd/cli/command/open.go
@@ -11,13 +11,14 @@ import (
 func NewOpenCommand(srv *client.Client) *cobra.Command {
 	var path string
 	var output string
+	var auto bool
 
 	c := &cobra.Command{
 		Use:   "open",
 		Short: "Opens blender with the specified version",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			if path == "" {
+			if auto && path == "" {
 				file, err := findBlendFile()
 				if err != nil {
 					cmd.PrintErrln(err)
@@ -33,8 +34,9 @@ func NewOpenCommand(srv *client.Client) *cobra.Command {
 		},
 	}
 
-	c.Flags().StringVarP(&path, "path", "p", "", "The path to a .blendfile")
-	c.Flags().StringVarP(&output, "output", "o", "cmd", "Output type of command")
+	c.Flags().StringVarP(&path, "path", "p", "", "The file path to a .blend file.")
+	c.Flags().StringVarP(&output, "output", "o", "cmd", "Output type of the command")
+	c.Flags().BoolVarP(&auto, "auto", "a", false, "Enables or disables the automatic detection of .blend files in the current directory.")
 
 	return c
 }


### PR DESCRIPTION
- Fixed issue with default executable not launching
- Added a new flag to the `open` command to automatically detect and open a blend file with the current folder