### PR TITLE
Removed the need to define the reference path in packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/rocketblend/rocketblend)](https://goreportcard.com/report/github.com/rocketblend/rocketblend)
 [![GitHub](https://img.shields.io/github/license/rocketblend/rocketblend)](https://github.com/rocketblend/rocketblend/blob/master/LICENSE)
 
-RocketBlend is an open-source tool that offers package and version management for the 3D graphics software, [Blender](https://www.blender.org/).
+RocketBlend is an open-source tool that offers build and addon management for the 3D graphics software, [Blender](https://www.blender.org/).
 
 ## About
 
@@ -15,13 +15,13 @@ RocketBlend consists of two parts: a CLI tool and a Launcher.
 
 ### CLI
 
-The command line tool is the primary application for managing your local installations of packages and Blender versions.
+The command line tool is the primary application for managing your local installations of addons and Blender versions.
 
 ### Launcher
 
-The Launcher is an alternative launcher for .blend files that utilizes a rocketfile.json file to determine the correct version of Blender and the packages to run.
+The Launcher is an alternative launcher for .blend files that utilizes a `rocketfile.json` file to determine the correct version of Blender and the addons to run.
 
-**Note: The Launcher is optional, but it allows you to open .blend files as you normally would while still maintaining package and build management.**
+**Note: The Launcher is optional, but it allows you to open .blend files as you normally would while still maintaining addon and build management.**
 
 ## Getting Started
 
@@ -29,7 +29,7 @@ See [Quick Start](https://docs.rocketblend.io/getting-started/quick-start) in ou
 
 ## See Also
 
-- [Official Library](https://github.com/rocketblend/official-library) - Collection of builds and packages.
+- [Official Library](https://github.com/rocketblend/official-library) - Collection of builds and addons.
 - [RocketBlend Collector](https://github.com/rocketblend/rocketblend-collector) - CLI tool for generating build collections from offical blender releases.
 - [RocketBlend Companion](https://github.com/rocketblend/rocketblend-companion) - Blender addon to aid with working with RocketBlend. **NOTE: WIP**
 
@@ -37,7 +37,7 @@ See [Quick Start](https://docs.rocketblend.io/getting-started/quick-start) in ou
 - CI/CD pipeline for releases.
 - Companion blender addon.
 - GUI project.
-- Searchable build and package website similar to [hub.docker.com](https://hub.docker.com/) or [pkg.go.dev](pkg.go.dev).
+- Searchable build and addon website similar to [hub.docker.com](https://hub.docker.com/) or [pkg.go.dev](pkg.go.dev).
 
 ## Acknowledgments
 

--- a/pkg/client/addon.go
+++ b/pkg/client/addon.go
@@ -2,7 +2,7 @@ package client
 
 import "github.com/rocketblend/rocketblend/pkg/jot/reference"
 
-func (c *Client) InstallPackage(ref reference.Reference) error {
+func (c *Client) InstallAddon(ref reference.Reference) error {
 	err := c.addon.FetchByReference(ref)
 	if err != nil {
 		return err

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -19,7 +19,7 @@ type (
 	}
 
 	AddonService interface {
-		FindByReference(ref reference.Reference) (*addon.Package, error)
+		FindByReference(ref reference.Reference) (*addon.Addon, error)
 		FetchByReference(ref reference.Reference) error
 		PullByReference(ref reference.Reference) error
 	}

--- a/pkg/client/executable.go
+++ b/pkg/client/executable.go
@@ -29,7 +29,7 @@ func (c *Client) findExecutableByBuildReference(ref string) (*executable.Executa
 		return nil, fmt.Errorf("failed to find build: %s", err)
 	}
 
-	addonMap, err := c.getExecutableAddonsByReference(build.Packages)
+	addonMap, err := c.getExecutableAddonsByReference(build.Addons)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find all addons for build: %s", err)
 	}

--- a/pkg/client/open.go
+++ b/pkg/client/open.go
@@ -14,10 +14,10 @@ import (
 
 type (
 	rocketFile struct {
-		Build    string   `json:"build"`
-		ARGS     string   `json:"args"`
-		Version  string   `json:"version"`
-		Packages []string `json:"packages"`
+		Build   string   `json:"build"`
+		ARGS    string   `json:"args"`
+		Version string   `json:"version"`
+		Addons  []string `json:"addons"`
 	}
 
 	blendFile struct {
@@ -87,7 +87,7 @@ func (c *Client) load(path string) (*blendFile, error) {
 		return nil, fmt.Errorf("failed to find executable: %s", err)
 	}
 
-	addons, err := c.getExecutableAddonsByReference(rkt.Packages)
+	addons, err := c.getExecutableAddonsByReference(rkt.Addons)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find all addon directories: %s", err)
 	}

--- a/pkg/cmd/cli/command/get.go
+++ b/pkg/cmd/cli/command/get.go
@@ -9,24 +9,24 @@ import (
 )
 
 func NewGetCommand(client *client.Client) *cobra.Command {
-	var pack string
+	var ref string
 
 	c := &cobra.Command{
 		Use:   "get",
-		Short: "Gets a new packge/addon for blender",
+		Short: "Gets a addon for blender",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := client.InstallPackage(reference.Reference(pack)); err != nil {
-				fmt.Printf("Error installing package: %v\n", err)
+			if err := client.InstallAddon(reference.Reference(ref)); err != nil {
+				fmt.Printf("Error installing addon: %v\n", err)
 				return
 			}
 
-			fmt.Printf("Package %s added to collection\n", pack)
+			fmt.Printf("addon %s added to collection\n", ref)
 		},
 	}
 
-	c.Flags().StringVarP(&pack, "package", "p", "", "package of the addon get")
-	if err := c.MarkFlagRequired("package"); err != nil {
+	c.Flags().StringVarP(&ref, "ref", "r", "", "reference of the addon to get (required)")
+	if err := c.MarkFlagRequired("ref"); err != nil {
 		fmt.Println(err)
 	}
 

--- a/pkg/cmd/cli/command/root.go
+++ b/pkg/cmd/cli/command/root.go
@@ -9,8 +9,8 @@ import (
 func NewCommand(srv *client.Client) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "rocketblend",
-		Short: "Version and package manager for blender.",
-		Long:  `RocketBlend is a tool for managing packages and versions of Blender.`,
+		Short: "Version and addon manager for blender.",
+		Long:  `RocketBlend is a tool for managing addons and versions of Blender.`,
 	}
 
 	c.SetVersionTemplate("{{.Version}}\n")

--- a/pkg/core/addon/service.go
+++ b/pkg/core/addon/service.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rocketblend/rocketblend/pkg/jot/reference"
 )
 
-const PackgeFile = "package.json"
+const PackgeFile = "addon.json"
 
 type Service struct {
 	driver *jot.Driver
@@ -20,13 +20,13 @@ func NewService(driver *jot.Driver) *Service {
 	}
 }
 
-func (srv *Service) FindByReference(ref reference.Reference) (*Package, error) {
+func (srv *Service) FindByReference(ref reference.Reference) (*Addon, error) {
 	b, err := srv.driver.Read(ref, PackgeFile)
 	if err != nil {
 		return nil, err
 	}
 
-	p := &Package{}
+	p := &Addon{}
 	if err := json.Unmarshal(b, p); err != nil {
 		return nil, err
 	}

--- a/pkg/core/addon/types.go
+++ b/pkg/core/addon/types.go
@@ -3,15 +3,15 @@ package addon
 import "github.com/rocketblend/rocketblend/pkg/semver"
 
 type (
-	PackageSource struct {
+	AddonSource struct {
 		File string `json:"file"`
 		URL  string `json:"url"`
 	}
 
-	Package struct {
+	Addon struct {
 		Reference    string         `json:"reference"`
 		Name         string         `json:"name"`
 		AddonVersion semver.Version `json:"addonVersion"`
-		Source       PackageSource  `json:"source"`
+		Source       AddonSource    `json:"source"`
 	}
 )

--- a/pkg/core/build/service.go
+++ b/pkg/core/build/service.go
@@ -63,7 +63,7 @@ func (srv *Service) FetchByReference(ref reference.Reference) error {
 		return err
 	}
 
-	for _, pack := range build.Packages {
+	for _, pack := range build.Addons {
 		err = srv.addonService.FetchByReference(reference.Reference(pack))
 		if err != nil {
 			return err
@@ -89,7 +89,7 @@ func (srv *Service) PullByReference(ref reference.Reference) error {
 		return err
 	}
 
-	for _, pack := range build.Packages {
+	for _, pack := range build.Addons {
 		err = srv.addonService.PullByReference(reference.Reference(pack))
 		if err != nil {
 			return err

--- a/pkg/core/build/types.go
+++ b/pkg/core/build/types.go
@@ -13,11 +13,10 @@ type (
 	}
 
 	Build struct {
-		Reference      string          `json:"reference"`
 		Args           string          `json:"args"`
 		BlenderVersion *semver.Version `json:"blenderVersion"`
 		Source         []*Source       `json:"source"`
-		Packages       []string        `json:"packages"`
+		Addons         []string        `json:"addons"`
 	}
 )
 


### PR DESCRIPTION
- Removed reference from builds/addons
- Renamed `packages` to `addons` to match Blender naming.