### PR TITLE
feat: render command upgrade

### DIFF
--- a/internal/cli/command/new.go
+++ b/internal/cli/command/new.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/rocketblend/rocketblend/pkg/helpers"
 	"github.com/rocketblend/rocketblend/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -127,7 +126,6 @@ func createProject(ctx context.Context, opts createProjectOpts) error {
 	if err := blender.Create(ctx, &types.CreateOpts{
 		BlenderOpts: types.BlenderOpts{
 			BlendFile: &types.BlendFile{
-				Name:         helpers.ExtractName(opts.Name),
 				Path:         blendFilePath,
 				Dependencies: resolveResults.Installations[0],
 			},

--- a/internal/cli/command/run.go
+++ b/internal/cli/command/run.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/rocketblend/rocketblend/pkg/helpers"
 	"github.com/rocketblend/rocketblend/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -84,7 +83,6 @@ func runProject(ctx context.Context, opts runProjectOpts) error {
 	if err := blender.Run(ctx, &types.RunOpts{
 		BlenderOpts: types.BlenderOpts{
 			BlendFile: &types.BlendFile{
-				Name:         helpers.ExtractName(blendFilePath),
 				Path:         blendFilePath,
 				Dependencies: resolve.Installations[0],
 			},

--- a/pkg/blender/argument.go
+++ b/pkg/blender/argument.go
@@ -15,8 +15,9 @@ type (
 		End     int
 		Step    int
 		Output  string
-		Format  types.RenderFormat
-		Devices []types.CyclesDevice
+		Format  RenderFormat
+		Devices []CyclesDevice
+		Engine  RenderEngine
 		Threads int
 	}
 
@@ -39,6 +40,10 @@ func (a *renderArguments) ARGS() []string {
 	}
 
 	args := []string{}
+	if a.Engine != "" {
+		args = append(args, "--engine", string(a.Engine))
+	}
+
 	if a.Start != 0 {
 		args = append(args, "--frame-start", fmt.Sprint(a.Start))
 	}

--- a/pkg/blender/device.go
+++ b/pkg/blender/device.go
@@ -1,4 +1,4 @@
-package types
+package blender
 
 // CyclesDevice represents the available devices for rendering with the Cycles engine.
 type CyclesDevice string

--- a/pkg/blender/engine.go
+++ b/pkg/blender/engine.go
@@ -1,0 +1,27 @@
+package blender
+
+import "github.com/rocketblend/rocketblend/pkg/types"
+
+const (
+	Default   RenderEngine = ""
+	Eevee     RenderEngine = "BLENDER_EEVEE"
+	Workbench RenderEngine = "BLENDER_WORKBENCH"
+	Cycles    RenderEngine = "CYCLES"
+)
+
+type (
+	RenderEngine string
+)
+
+func convertRenderEngine(engine types.RenderEngine) RenderEngine {
+	switch engine {
+	case types.Eevee:
+		return Eevee
+	case types.Workbench:
+		return Workbench
+	case types.Cycles:
+		return Cycles
+	default:
+		return Default
+	}
+}

--- a/pkg/blender/format.go
+++ b/pkg/blender/format.go
@@ -1,4 +1,4 @@
-package types
+package blender
 
 // RenderFormat represents the available formats for rendering.
 type RenderFormat string

--- a/pkg/blender/render.go
+++ b/pkg/blender/render.go
@@ -25,9 +25,9 @@ func (b *Blender) Render(ctx context.Context, opts *types.RenderOpts) error {
 			End:     opts.End,
 			Step:    opts.Step,
 			Output:  opts.Output,
-			Format:  opts.Format,
-			Devices: opts.CyclesDevices,
+			Format:  RenderFormat(opts.Format),
 			Threads: opts.Threads,
+			Engine:  convertRenderEngine(opts.Engine),
 		},
 	}
 
@@ -38,8 +38,8 @@ func (b *Blender) Render(ctx context.Context, opts *types.RenderOpts) error {
 		"end":       opts.End,
 		"step":      opts.Step,
 		"format":    opts.Format,
-		"devices":   opts.CyclesDevices,
 		"threads":   opts.Threads,
+		"engine":    opts.Engine,
 	})
 
 	if opts.BlendFile.Addons() != nil {

--- a/pkg/blender/render.go
+++ b/pkg/blender/render.go
@@ -4,25 +4,11 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	"github.com/rocketblend/rocketblend/pkg/helpers"
 	"github.com/rocketblend/rocketblend/pkg/types"
-)
-
-type (
-	outputPathData struct {
-		Name string `json:"name"`
-	}
 )
 
 func (b *Blender) Render(ctx context.Context, opts *types.RenderOpts) error {
 	if err := b.validator.Validate(opts); err != nil {
-		return err
-	}
-
-	outputPath, err := helpers.ParseTemplateWithData(opts.Output, &outputPathData{
-		Name: opts.BlendFile.Name,
-	})
-	if err != nil {
 		return err
 	}
 
@@ -38,12 +24,23 @@ func (b *Blender) Render(ctx context.Context, opts *types.RenderOpts) error {
 			Start:   opts.Start,
 			End:     opts.End,
 			Step:    opts.Step,
-			Output:  outputPath,
+			Output:  opts.Output,
 			Format:  opts.Format,
 			Devices: opts.CyclesDevices,
 			Threads: opts.Threads,
 		},
 	}
+
+	b.logger.Info("rendering", map[string]interface{}{
+		"blendFile": opts.BlendFile.Path,
+		"output":    opts.Output,
+		"start":     opts.Start,
+		"end":       opts.End,
+		"step":      opts.Step,
+		"format":    opts.Format,
+		"devices":   opts.CyclesDevices,
+		"threads":   opts.Threads,
+	})
 
 	if opts.BlendFile.Addons() != nil {
 		arguments.Script = startupScript()

--- a/pkg/blender/template.go
+++ b/pkg/blender/template.go
@@ -43,7 +43,7 @@ func FindMaxRevision(templatedPath string) (int, error) {
 		return -1, err
 	}
 
-	maxRevision := -1
+	maxRevision := 0
 	revisionNumberPattern := regexp.MustCompile(`\d+$`)
 	for _, dir := range directories {
 		base := filepath.Base(dir)

--- a/pkg/blender/template.go
+++ b/pkg/blender/template.go
@@ -1,0 +1,99 @@
+package blender
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	RevisionTempalteVariable = "{{.Revision}}"
+	NameTemplateVariable     = "{{.Name}}"
+)
+
+type (
+	TemplatedOutputData struct {
+		Name     string `json:"name"`
+		Revision string `json:"revision"`
+	}
+)
+
+var ErrInvalidPath = errors.New("path should not start with //")
+
+func FindMaxRevision(templatedPath string) (int, error) {
+	if strings.HasPrefix(templatedPath, "//") {
+		return -1, ErrInvalidPath
+	}
+
+	dirPath := filepath.Dir(templatedPath)
+
+	revisionDirPattern := regexp.MustCompile(RevisionTempalteVariable)
+	if !revisionDirPattern.MatchString(dirPath) {
+		return -1, fmt.Errorf("no {{.Revision}} placeholder found in the path")
+	}
+
+	searchPath := revisionDirPattern.ReplaceAllString(dirPath, "*")
+
+	directories, err := filepath.Glob(searchPath)
+	if err != nil {
+		return -1, err
+	}
+
+	maxRevision := -1
+	revisionNumberPattern := regexp.MustCompile(`\d+$`)
+	for _, dir := range directories {
+		base := filepath.Base(dir)
+		if matches := revisionNumberPattern.FindStringSubmatch(base); matches != nil {
+			revNum, _ := strconv.Atoi(matches[0])
+			if revNum > maxRevision {
+				maxRevision = revNum
+			}
+		}
+	}
+
+	return maxRevision, nil
+}
+
+func FindMaxFrameNumber(templatedPath string) (int, error) {
+	baseName := filepath.Base(templatedPath)
+	directory := filepath.Dir(templatedPath)
+
+	numFormatRegex := regexp.MustCompile(`#+`)
+	numFormat := numFormatRegex.FindString(baseName)
+	if numFormat == "" {
+		return -1, fmt.Errorf("no number placeholder found in filename pattern")
+	}
+
+	regexPattern := regexp.QuoteMeta(strings.Replace(baseName, numFormat, "REPLACEME", 1))
+	regexPattern = strings.Replace(regexPattern, "REPLACEME", `(\d{`+strconv.Itoa(len(numFormat))+`})`, 1)
+	re := regexp.MustCompile(regexPattern)
+
+	files, err := os.ReadDir(directory)
+	if err != nil {
+		return -1, fmt.Errorf("unable to read directory %s: %w", directory, err)
+	}
+
+	maxFrame := -1
+
+	for _, file := range files {
+		if matches := re.FindStringSubmatch(file.Name()); matches != nil {
+			frameNumber, err := strconv.Atoi(matches[1])
+			if err != nil {
+				continue // skip files with non-integer frame numbers
+			}
+			if frameNumber > maxFrame {
+				maxFrame = frameNumber
+			}
+		}
+	}
+
+	if maxFrame == -1 {
+		return -1, fmt.Errorf("no frame files found in %s", directory)
+	}
+
+	return maxFrame, nil
+}

--- a/pkg/helpers/text.go
+++ b/pkg/helpers/text.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 )
@@ -8,4 +9,13 @@ import (
 func ExtractName(path string) string {
 	base := filepath.Base(path)
 	return strings.TrimSuffix(base, filepath.Ext(base))
+}
+
+func PadWithZero(num int, padLength int) string {
+	numStr := fmt.Sprintf("%d", num)
+	if len(numStr) >= padLength {
+		return numStr
+	}
+
+	return strings.Repeat("0", padLength-len(numStr)) + numStr // Pad and return
 }

--- a/pkg/types/blender.go
+++ b/pkg/types/blender.go
@@ -14,7 +14,6 @@ type (
 	}
 
 	BlendFile struct {
-		Name         string          `json:"name" validate:"required"`
 		Path         string          `json:"path" validate:"required,filepath,blendfile"`
 		Dependencies []*Installation `json:"dependencies" validate:"required,onebuild,dive,required"`
 	}

--- a/pkg/types/blender.go
+++ b/pkg/types/blender.go
@@ -24,13 +24,13 @@ type (
 	}
 
 	RenderOpts struct {
-		Start         int            `json:"start"`
-		End           int            `json:"end"`
-		Step          int            `json:"step"`
-		Output        string         `json:"output"`
-		Format        RenderFormat   `json:"format"`
-		CyclesDevices []CyclesDevice `json:"cyclesDevices"`
-		Threads       int            `json:"threads" validate:"omitempty,gte=0,lte=1024"`
+		Start   int          `json:"start"`
+		End     int          `json:"end"`
+		Step    int          `json:"step"`
+		Output  string       `json:"output"`
+		Format  string       `json:"format"`
+		Engine  RenderEngine `json:"engine" validate:"omitempty,oneof=cycles eevee workbench"`
+		Threads int          `json:"threads" validate:"omitempty,gte=0,lte=1024"`
 		BlenderOpts
 	}
 

--- a/pkg/types/engine.go
+++ b/pkg/types/engine.go
@@ -1,0 +1,12 @@
+package types
+
+type (
+	RenderEngine string
+)
+
+const (
+	Default   RenderEngine = ""
+	Eevee     RenderEngine = "eevee"
+	Workbench RenderEngine = "workbench"
+	Cycles    RenderEngine = "cycles"
+)


### PR DESCRIPTION
- Added render engine override to render command (cycles, eevee, workbench)
- Added revision folder for renders. You can now specify a revision or allow the tool to auto increment a revision number for the output path of a render. This means that by default each run of the render command will store all frames in a new sub folder.
- Added a continue flag for the render command, allow you to continue a render from the last frame outputted. 
- Reworded/renamed some command flags.