### PR TITLE
fix: template obfuscation

### DIFF
--- a/pkg/blender/blender.go
+++ b/pkg/blender/blender.go
@@ -1,6 +1,8 @@
 package blender
 
 import (
+	"reflect"
+
 	"github.com/flowshot-io/x/pkg/logger"
 	"github.com/rocketblend/rocketblend/pkg/types"
 	"github.com/rocketblend/rocketblend/pkg/validator"
@@ -18,6 +20,12 @@ type (
 		logger    types.Logger
 		validator types.Validator
 	}
+)
+
+var (
+	// Never obfuscate these type (Garble)
+	_ = reflect.TypeOf(TemplatedOutputData{})
+	_ = reflect.TypeOf(CreateBlendFileData{})
 )
 
 func WithLogger(logger types.Logger) Option {

--- a/pkg/blender/create.go
+++ b/pkg/blender/create.go
@@ -23,7 +23,7 @@ func (b *Blender) Create(ctx context.Context, opts *types.CreateOpts) error {
 		return errors.New("missing build")
 	}
 
-	script, err := createBlendFileScript(&createBlendFileData{
+	script, err := createBlendFileScript(&CreateBlendFileData{
 		FilePath: opts.BlendFile.Path,
 	})
 	if err != nil {

--- a/pkg/blender/script.go
+++ b/pkg/blender/script.go
@@ -6,12 +6,12 @@ import (
 )
 
 type (
-	createBlendFileData struct {
+	CreateBlendFileData struct {
 		FilePath string `json:"filePath"`
 	}
 )
 
-func createBlendFileScript(data *createBlendFileData) (string, error) {
+func createBlendFileScript(data *CreateBlendFileData) (string, error) {
 	result, err := helpers.ParseTemplateWithData(python.CreateScript, data)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
- The desktop application use obfuscation (garble) to stop common packages (go archive) flagging the whole application as malware. This obfuscation was breaking templates so this changes fixes that.