### PR TITLE
feat!: consolidate project data into `.rocketblend` folder

### DIFF
--- a/internal/cli/command/new.go
+++ b/internal/cli/command/new.go
@@ -140,6 +140,7 @@ func createProject(ctx context.Context, opts createProjectOpts) error {
 		Profiles: map[string]*types.Profile{
 			filepath.Dir(blendFilePath): profiles[0],
 		},
+		EnsurePaths: true,
 	}); err != nil {
 		return err
 	}

--- a/pkg/driver/save.go
+++ b/pkg/driver/save.go
@@ -50,5 +50,5 @@ func (d *Driver) save(ctx context.Context, path string, profile *types.Profile) 
 }
 
 func profileFilePath(path string) string {
-	return filepath.Join(path, types.ProfileFileName)
+	return filepath.Join(path, types.ProfileDirName, types.ProfileFileName)
 }

--- a/pkg/driver/save.go
+++ b/pkg/driver/save.go
@@ -2,8 +2,6 @@ package driver
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/rocketblend/rocketblend/pkg/helpers"
@@ -34,25 +32,18 @@ func (d *Driver) SaveProfiles(ctx context.Context, opts *types.SaveProfilesOpts)
 	return nil
 }
 
-func (d *Driver) save(ctx context.Context, path string, profile *types.Profile, ensurePaths bool) error {
+func (d *Driver) save(ctx context.Context, path string, profile *types.Profile, ensurePath bool) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 
 	savePath := profileFilePath(path)
-	if ensurePaths {
-		dir := filepath.Dir(savePath)
-		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-			return fmt.Errorf("failed to create directory: %w", err)
-		}
-	}
-
 	d.logger.Debug("saving profile", map[string]interface{}{
 		"path":    savePath,
 		"profile": profile,
 	})
 
-	if err := helpers.Save(d.validator, savePath, profile); err != nil {
+	if err := helpers.Save(d.validator, savePath, ensurePath, profile); err != nil {
 		return err
 	}
 

--- a/pkg/helpers/data.go
+++ b/pkg/helpers/data.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/rocketblend/rocketblend/pkg/types"
 )
@@ -35,7 +36,7 @@ func Load[T any](validator types.Validator, filePath string) (*T, error) {
 	return &result, nil
 }
 
-func Save[T any](validator types.Validator, filePath string, object *T) error {
+func Save[T any](validator types.Validator, filePath string, ensurePath bool, object *T) error {
 	if validator == nil {
 		return errors.New("validator is required")
 	}
@@ -47,6 +48,12 @@ func Save[T any](validator types.Validator, filePath string, object *T) error {
 	bytes, err := json.MarshalIndent(object, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal object: %s", err)
+	}
+
+	if ensurePath {
+		if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+			return fmt.Errorf("failed to create parent directory: %w", err)
+		}
 	}
 
 	if err := os.WriteFile(filePath, bytes, 0644); err != nil {

--- a/pkg/repository/package.go
+++ b/pkg/repository/package.go
@@ -132,13 +132,7 @@ func (r *Repository) insertPackage(ctx context.Context, ref reference.Reference,
 
 	packagePath := filepath.Join(r.packagePath, ref.String(), types.PackageFileName)
 
-	err := os.MkdirAll(filepath.Dir(packagePath), 0755)
-	if err != nil {
-		r.logger.Error("error creating directory", map[string]interface{}{"error": err, "reference": ref.String(), "path": filepath.Dir(packagePath)})
-		return err
-	}
-
-	if err := helpers.Save(r.validator, packagePath, pack); err != nil {
+	if err := helpers.Save(r.validator, packagePath, true, pack); err != nil {
 		r.logger.Error("error saving package", map[string]interface{}{
 			"error":     err,
 			"reference": ref.String(),

--- a/pkg/types/driver.go
+++ b/pkg/types/driver.go
@@ -31,7 +31,8 @@ type (
 	}
 
 	SaveProfilesOpts struct {
-		Profiles map[string]*Profile `json:"profiles" validate:"required,dive,required"`
+		Profiles    map[string]*Profile `json:"profiles" validate:"required,dive,required"` // Path to profile
+		EnsurePaths bool                `json:"ensurePaths"`                                // Ensure paths exist before saving
 	}
 
 	Driver interface {

--- a/pkg/types/profile.go
+++ b/pkg/types/profile.go
@@ -5,7 +5,10 @@ import (
 	"github.com/rocketblend/rocketblend/pkg/semver"
 )
 
-const ProfileFileName = "rocketblend.json"
+const (
+	ProfileDirName  = ".rocketblend"
+	ProfileFileName = "profile.json"
+)
 
 type (
 	Dependency struct {
@@ -19,11 +22,6 @@ type (
 		Strict       bool           `json:"strict,omitempty"`
 		// ARGS         []string       `json:"args,omitempty"`
 	}
-
-	// Project struct {
-	// 	BlendFilePath string   `json:"blendFilePath" validate:"required,filepath,blendfile"`
-	// 	Profile       *Profile `json:"config" validate:"required"`
-	// }
 )
 
 func (p *Profile) FindAll(packageType PackageType) []*Dependency {
@@ -56,20 +54,3 @@ func (p *Profile) RemoveDependencies(deps ...*Dependency) {
 		}
 	}
 }
-
-// func (p *Project) Dir() string {
-// 	return filepath.Dir(p.BlendFilePath)
-// }
-
-// func (p *Project) Name() string {
-// 	fileName := filepath.Base(p.BlendFilePath)
-// 	return strings.TrimSuffix(fileName, filepath.Ext(fileName))
-// }
-
-// func (p *Project) Requires() []*Dependency {
-// 	if p.Profile == nil {
-// 		return nil
-// 	}
-
-// 	return p.Profile.Dependencies
-// }


### PR DESCRIPTION
We are consolidating all project data into a single .`rocketblend` folder within each project. Inspired by Obsidian's vault system, this approach improves organisation and creates a dedicated space for future metadata, while also reducing clutter in the project directory.

Changes include:

- `rocketblend.json` -> `.rocketblend/profile.json`
- `rocketdesk.json` -> `.rocketblend/meta.json` (PR to be created.)

This is a breaking change so will require user to migrate to this new format.
