### PR TITLE
feat: create profile for existing project

### DIFF
--- a/internal/cli/command/helpers.go
+++ b/internal/cli/command/helpers.go
@@ -29,8 +29,6 @@ type spinnerOptions struct {
 // }
 
 func findFilePathForExt(dir string, ext string) (string, error) {
-	// Get a list of all files in the current directory.
-
 	files, err := filepath.Glob(filepath.Join(dir, "*"+ext))
 	if err != nil {
 		return "", fmt.Errorf("failed to list files in current directory: %w", err)

--- a/internal/cli/command/install.go
+++ b/internal/cli/command/install.go
@@ -107,6 +107,7 @@ func installPackage(ctx context.Context, opts installPackageOpts) error {
 		Profiles: map[string]*types.Profile{
 			opts.Global.WorkingDirectory: profiles.Profiles[0],
 		},
+		Overwrite: true,
 	}); err != nil {
 		return err
 	}

--- a/internal/cli/command/new.go
+++ b/internal/cli/command/new.go
@@ -63,9 +63,7 @@ func newNewCommand(opts commandOpts) *cobra.Command {
 // createProject creates a new project with the specified name.
 func createProject(ctx context.Context, opts createProjectOpts) error {
 	existingProject := existingProject(opts.Global.WorkingDirectory)
-	existingProfile := existingProfile(opts.Global.WorkingDirectory)
-
-	if !opts.Overwrite && existingProject && existingProfile {
+	if !opts.Overwrite && existingProject {
 		return errors.New("project already exists in directory")
 	}
 
@@ -153,6 +151,7 @@ func createProject(ctx context.Context, opts createProjectOpts) error {
 			filepath.Dir(blendFilePath): profiles.Profiles[0],
 		},
 		EnsurePaths: true,
+		Overwrite:   opts.Overwrite,
 	}); err != nil {
 		return err
 	}
@@ -162,12 +161,17 @@ func createProject(ctx context.Context, opts createProjectOpts) error {
 
 // existingProject checks if a project already exists at the specified path.
 func existingProject(path string) bool {
+	return existingBlendFile(path) && existingProfileDir(path)
+}
+
+// existingBlendFile checks if a blend file already exists at the specified path.
+func existingBlendFile(path string) bool {
 	_, err := findFilePathForExt(path, types.BlendFileExtension)
 	return err == nil
 }
 
 // existingProfile checks if a profile already exists at the specified path.
-func existingProfile(path string) bool {
+func existingProfileDir(path string) bool {
 	profilePath := filepath.Join(path, types.ProfileDirName)
 	info, err := os.Stat(profilePath)
 	if err != nil {

--- a/internal/cli/command/uninstall.go
+++ b/internal/cli/command/uninstall.go
@@ -74,6 +74,7 @@ func uninstallPackage(ctx context.Context, opts uninstallPackageOpts) error {
 		Profiles: map[string]*types.Profile{
 			opts.Global.WorkingDirectory: profiles.Profiles[0],
 		},
+		Overwrite: true,
 	}); err != nil {
 		return err
 	}

--- a/pkg/blender/create.go
+++ b/pkg/blender/create.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
+	"github.com/rocketblend/rocketblend/pkg/helpers"
 	"github.com/rocketblend/rocketblend/pkg/types"
 )
 
@@ -14,13 +14,24 @@ func (b *Blender) Create(ctx context.Context, opts *types.CreateOpts) error {
 		return err
 	}
 
+	if err := helpers.FileExists(opts.BlendFile.Path); err == nil {
+		if !opts.Overwrite {
+			return types.ErrFileExists
+		}
+
+		// TODO: Look into doing soft deletes.
+		if err := os.Remove(opts.BlendFile.Path); err != nil {
+			return err
+		}
+	}
+
 	if err := os.MkdirAll(filepath.Dir(opts.BlendFile.Path), 0755); err != nil {
 		return err
 	}
 
 	build := opts.BlendFile.Build()
 	if build == nil {
-		return errors.New("missing build")
+		return types.ErrMissingBlenderBuild
 	}
 
 	script, err := createBlendFileScript(&CreateBlendFileData{

--- a/pkg/driver/save.go
+++ b/pkg/driver/save.go
@@ -16,7 +16,7 @@ func (d *Driver) SaveProfiles(ctx context.Context, opts *types.SaveProfilesOpts)
 	tasks := make([]taskrunner.Task[struct{}], 0, len(opts.Profiles))
 	for path, profile := range opts.Profiles {
 		tasks = append(tasks, func(ctx context.Context) (struct{}, error) {
-			return struct{}{}, d.save(ctx, path, profile, opts.EnsurePaths)
+			return struct{}{}, d.save(ctx, path, profile, opts.EnsurePaths, opts.Overwrite)
 		})
 	}
 
@@ -32,7 +32,7 @@ func (d *Driver) SaveProfiles(ctx context.Context, opts *types.SaveProfilesOpts)
 	return nil
 }
 
-func (d *Driver) save(ctx context.Context, path string, profile *types.Profile, ensurePath bool) error {
+func (d *Driver) save(ctx context.Context, path string, profile *types.Profile, ensurePath bool, overwrite bool) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -43,7 +43,7 @@ func (d *Driver) save(ctx context.Context, path string, profile *types.Profile, 
 		"profile": profile,
 	})
 
-	if err := helpers.Save(d.validator, savePath, ensurePath, profile); err != nil {
+	if err := helpers.Save(d.validator, savePath, profile, ensurePath, overwrite); err != nil {
 		return err
 	}
 

--- a/pkg/helpers/data.go
+++ b/pkg/helpers/data.go
@@ -16,7 +16,7 @@ func Load[T any](validator types.Validator, filePath string) (*T, error) {
 	}
 
 	if err := FileExists(filePath); err != nil {
-		return nil, fmt.Errorf("failed to find file: %s", err)
+		return nil, err
 	}
 
 	f, err := os.ReadFile(filePath)

--- a/pkg/helpers/data.go
+++ b/pkg/helpers/data.go
@@ -36,7 +36,7 @@ func Load[T any](validator types.Validator, filePath string) (*T, error) {
 	return &result, nil
 }
 
-func Save[T any](validator types.Validator, filePath string, ensurePath bool, object *T) error {
+func Save[T any](validator types.Validator, filePath string, object *T, ensurePath bool, override bool) error {
 	if validator == nil {
 		return errors.New("validator is required")
 	}
@@ -48,6 +48,12 @@ func Save[T any](validator types.Validator, filePath string, ensurePath bool, ob
 	bytes, err := json.MarshalIndent(object, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal object: %s", err)
+	}
+
+	if !override {
+		if err := FileExists(filePath); err == nil {
+			return types.ErrFileExists
+		}
 	}
 
 	if ensurePath {

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/flowshot-io/x/pkg/logger"
 	"github.com/pkg/errors"
+	"github.com/rocketblend/rocketblend/pkg/types"
 )
 
 func ValidateFilePath(filePath string, requiredFileName string) error {
@@ -25,7 +26,7 @@ func ValidateFilePath(filePath string, requiredFileName string) error {
 func FileExists(filePath string) error {
 	info, err := os.Stat(filePath)
 	if os.IsNotExist(err) {
-		return errors.New("file does not exist")
+		return types.ErrFileNotFound
 	}
 
 	if info.IsDir() {

--- a/pkg/repository/package.go
+++ b/pkg/repository/package.go
@@ -131,8 +131,7 @@ func (r *Repository) insertPackage(ctx context.Context, ref reference.Reference,
 	}
 
 	packagePath := filepath.Join(r.packagePath, ref.String(), types.PackageFileName)
-
-	if err := helpers.Save(r.validator, packagePath, true, pack); err != nil {
+	if err := helpers.Save(r.validator, packagePath, pack, true, true); err != nil {
 		r.logger.Error("error saving package", map[string]interface{}{
 			"error":     err,
 			"reference": ref.String(),

--- a/pkg/types/blender.go
+++ b/pkg/types/blender.go
@@ -41,6 +41,7 @@ type (
 
 	CreateOpts struct {
 		BlenderOpts
+		Overwrite bool `json:"overwrite"`
 	}
 
 	Blender interface {

--- a/pkg/types/driver.go
+++ b/pkg/types/driver.go
@@ -34,6 +34,7 @@ type (
 	SaveProfilesOpts struct {
 		Profiles    map[string]*Profile `json:"profiles" validate:"required,dive,required"` // Path to profile
 		EnsurePaths bool                `json:"ensurePaths"`                                // Ensure paths exist before saving
+		Overwrite   bool                `json:"overwrite"`
 	}
 
 	Driver interface {

--- a/pkg/types/driver.go
+++ b/pkg/types/driver.go
@@ -6,7 +6,8 @@ import (
 
 type (
 	LoadProfilesOpts struct {
-		Paths []string `json:"paths" validate:"required,dive,dir"`
+		Paths   []string `json:"paths" validate:"required,dive,dir"`
+		Default *Profile `json:"default"`
 	}
 
 	LoadProfilesResult struct {

--- a/pkg/types/errors.go
+++ b/pkg/types/errors.go
@@ -1,0 +1,10 @@
+package types
+
+import "errors"
+
+var (
+	ErrFileNotFound = errors.New("file not found")
+	ErrFileExists   = errors.New("file already exists")
+
+	ErrMissingBlenderBuild = errors.New("missing blender build")
+)


### PR DESCRIPTION
-  Updated `new` command to support adding `.rocketblend` data to an existing `.blend` file.
- `new` name argument is now optional and will generate a name from the parent directory.