### PR TITLE
feat: reference aliases

### DIFF
--- a/internal/cli/command/install.go
+++ b/internal/cli/command/install.go
@@ -80,7 +80,17 @@ func installPackage(ctx context.Context, opts installPackageOpts) error {
 	}
 
 	if opts.Reference != "" {
-		ref, err := reference.Parse(opts.Reference)
+		configurator, err := container.GetConfigurator()
+		if err != nil {
+			return err
+		}
+
+		config, err := configurator.Get()
+		if err != nil {
+			return err
+		}
+
+		ref, err := reference.Aliased(opts.Reference, config.Aliases)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/command/uninstall.go
+++ b/internal/cli/command/uninstall.go
@@ -39,17 +39,27 @@ func newUninstallCommand(opts commandOpts) *cobra.Command {
 }
 
 func uninstallPackage(ctx context.Context, opts uninstallPackageOpts) error {
-	ref, err := reference.Parse(opts.Reference)
-	if err != nil {
-		return err
-	}
-
 	container, err := getContainer(containerOpts{
 		AppName:     opts.AppName,
 		Development: opts.Development,
 		Level:       opts.Global.Level,
 		Verbose:     opts.Global.Verbose,
 	})
+	if err != nil {
+		return err
+	}
+
+	configurator, err := container.GetConfigurator()
+	if err != nil {
+		return err
+	}
+
+	config, err := configurator.Get()
+	if err != nil {
+		return err
+	}
+
+	ref, err := reference.Aliased(opts.Reference, config.Aliases)
 	if err != nil {
 		return err
 	}

--- a/pkg/configurator/configurator.go
+++ b/pkg/configurator/configurator.go
@@ -176,6 +176,7 @@ func load(path string, name string, extension string) (*viper.Viper, error) {
 	v.SetDefault("logLevel", "info")
 	v.SetDefault("installationsPath", filepath.Join(path, "installations"))
 	v.SetDefault("packagesPath", filepath.Join(path, "packages"))
+	v.SetDefault("aliases", types.DefaultAliases)
 
 	v.SetConfigName(name)      // Set the name of the configuration file
 	v.AddConfigPath(path)      // Look for the configuration file at the home directory

--- a/pkg/reference/reference.go
+++ b/pkg/reference/reference.go
@@ -97,9 +97,9 @@ func Aliased(input string, aliases map[string]string) (Reference, error) {
 		if strings.HasPrefix(input, alias) {
 			remainingPath := strings.TrimPrefix(input, alias)
 			resolved := path.Join(fullPath, remainingPath)
-			return Reference(resolved), nil
+			return Parse(resolved)
 		}
 	}
 
-	return "", fmt.Errorf("failed to resolve reference: %s", input)
+	return Parse(input)
 }

--- a/pkg/reference/reference_test.go
+++ b/pkg/reference/reference_test.go
@@ -1,0 +1,128 @@
+package reference_test
+
+import (
+	"testing"
+
+	"github.com/rocketblend/rocketblend/pkg/reference"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		expectErr bool
+		expected  string
+	}{
+		{
+			name:     "Valid reference",
+			input:    "domain.com/base/repo/v1/builds/module/1.0",
+			expected: "domain.com/base/repo/v1/builds/module/1.0",
+		},
+		{
+			name:      "Invalid reference (missing parts)",
+			input:     "domain.com/base/repo",
+			expectErr: true,
+		},
+		{
+			name:     "Valid local reference",
+			input:    "local/builds/module",
+			expected: "local/builds/module",
+		},
+		{
+			name:      "Invalid local reference (missing parts)",
+			input:     "local/",
+			expectErr: true,
+		},
+		{
+			name:      "Reference with extra slashes",
+			input:     "domain.com/base//repo/v1//builds/module",
+			expectErr: true,
+		},
+		{
+			name:      "Empty input",
+			input:     "",
+			expectErr: true,
+		},
+		{
+			name:      "Reference with only slashes",
+			input:     "///",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := reference.Parse(tt.input)
+			if (err != nil) != tt.expectErr {
+				t.Fatalf("expected error: %v, got: %v", tt.expectErr, err)
+			}
+			if !tt.expectErr && string(result) != tt.expected {
+				t.Errorf("expected: %s, got: %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestAliased(t *testing.T) {
+	aliases := map[string]string{
+		"domain.com/base/repo/v1/builds":           "builds",
+		"domain.com/base/repo/v1/addons":           "addons",
+		"domain.com/base/repo/v1/builds/tools":     "tools",
+		"domain.com/base/repo/v1/builds/tools/dev": "dev",
+	}
+
+	tests := []struct {
+		name      string
+		input     string
+		expected  string
+		expectErr bool
+	}{
+		{
+			name:     "Simple alias match",
+			input:    "builds/module/1.0",
+			expected: "domain.com/base/repo/v1/builds/module/1.0",
+		},
+		{
+			name:     "Nested alias match",
+			input:    "tools/utilities/v2",
+			expected: "domain.com/base/repo/v1/builds/tools/utilities/v2",
+		},
+		{
+			name:     "Deep nested alias match",
+			input:    "dev/project/alpha",
+			expected: "domain.com/base/repo/v1/builds/tools/dev/project/alpha",
+		},
+		{
+			name:     "Another alias match",
+			input:    "addons/theme/2.3.4",
+			expected: "domain.com/base/repo/v1/addons/theme/2.3.4",
+		},
+		{
+			name:      "No matching alias",
+			input:     "unknown/path",
+			expectErr: true,
+		},
+		{
+			name:      "Empty input",
+			input:     "",
+			expectErr: true,
+		},
+		{
+			name:     "Alias without additional path",
+			input:    "builds",
+			expected: "domain.com/base/repo/v1/builds",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := reference.Aliased(tt.input, aliases)
+			if (err != nil) != tt.expectErr {
+				t.Fatalf("expected error: %v, got: %v", tt.expectErr, err)
+			}
+			if !tt.expectErr && string(result) != tt.expected {
+				t.Errorf("expected: %s, got: %s", tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/reference/reference_test.go
+++ b/pkg/reference/reference_test.go
@@ -78,6 +78,11 @@ func TestAliased(t *testing.T) {
 		expectErr bool
 	}{
 		{
+			name:     "No alias match",
+			input:    "domain.com/base/repo/v1/builds/example/1.0",
+			expected: "domain.com/base/repo/v1/builds/example/1.0",
+		},
+		{
 			name:     "Simple alias match",
 			input:    "builds/module/1.0",
 			expected: "domain.com/base/repo/v1/builds/module/1.0",

--- a/pkg/types/configurator.go
+++ b/pkg/types/configurator.go
@@ -5,8 +5,14 @@ import (
 	"github.com/rocketblend/rocketblend/pkg/runtime"
 )
 
+const DefaultBuild = "github.com/rocketblend/official-library/packages/v0/builds/blender/4.2.2"
+
 var (
-	DefaultBuild = "github.com/rocketblend/official-library/packages/v0/builds/blender/4.2.2"
+	DefaultAliases = map[string]string{
+		"github.com/rocketblend/official-library/packages/v0/builds":         "builds",
+		"github.com/rocketblend/official-library/packages/v0/addons":         "addons",
+		"github.com/rocketblend/official-library/packages/v0/builds/blender": "blender",
+	}
 )
 
 type (
@@ -15,6 +21,7 @@ type (
 		DefaultBuild      reference.Reference `mapstructure:"defaultBuild"`
 		InstallationsPath string              `mapstructure:"installationsPath"`
 		PackagesPath      string              `mapstructure:"packagesPath"`
+		Aliases           map[string]string   `mapstructure:"aliases"`
 	}
 
 	Configurator interface {


### PR DESCRIPTION
You can now define reference aliases in your config to shorten what you need to type to install/uninstall something.

By default we now have:

'builds` - `github.com/rocketblend/official-library/packages/v0/builds` 
`github.com/rocketblend/official-library/packages/v0/addons` - `addons`
`github.com/rocketblend/official-library/packages/v0/builds/blender` - `blender`

Installing `github.com/rocketblend/official-library/packages/v0/builds/blender/4.2.2` now becomes `builds/blender/4.2.2` or `blender/4.2.2`. With the full command looking like `rocketblend install blender/4.2.2`.

Using the full reference is still supported. Custom aliases can be added via config.

This is a massive improvement in terms of usability. 